### PR TITLE
Rename workflow to 'Copilot Setup Steps'

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,4 @@
-name: GitHub Copilot Development Environment Setup
+name: "Copilot Setup Steps"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
fix copilot setup issue, per the error message from the PR from @lilyclemson 